### PR TITLE
Fix error when generate tests from praspel

### DIFF
--- a/Atoum/PraspelExtension/Bin/Command/Generate.php
+++ b/Atoum/PraspelExtension/Bin/Command/Generate.php
@@ -133,7 +133,7 @@ class Generate extends Console\Dispatcher\Kit {
                 'Bootstrap file %s does not exist.', 1, $bootstrap);
 
         $generator = new Extension\Praspel\Generator();
-        $generator->setTestNamespacer(function ( $namesace ) use ( $testNamespace ) {
+        $generator->setTestNamespacer(function ( $namespace ) use ( $testNamespace ) {
 
             return $testNamespace . '\\' . $namespace;
         });


### PR DESCRIPTION
Fix variable name `$namespace` during generation of tests from praspel

command: 

`./vendor/bin/praspel generate -c namespace\\class -r .`
