### PR TITLE
Use an iterator instead of an array in sampleMany

### DIFF
--- a/Atoum/PraspelExtension/Asserter/Realdom.php
+++ b/Atoum/PraspelExtension/Asserter/Realdom.php
@@ -39,6 +39,7 @@ namespace Atoum\PraspelExtension\Asserter;
 use mageekguy\atoum;
 use Atoum\PraspelExtension\Praspel\Model\Variable;
 use Hoa\Realdom as HoaRealdom;
+use Hoa\Iterator as HoaIterator;
 
 /**
  * Class \Atoum\PraspelExtension\Asserter\Realdom.
@@ -101,11 +102,15 @@ class Realdom extends atoum\asserter {
      */
     public function sampleMany ( HoaRealdom\Disjunction $realdoms, $n = 7 ) {
 
-        $out = new \SplFixedArray($n);
+        return new HoaIterator\Limit(
+            new HoaIterator\CallbackGenerator(
+                function ( ) use ( $realdoms ) {
 
-        for(--$n; $n >= 0; --$n)
-            $out[$n] = $realdoms->sample();
-
-        return $out;
+                    return $realdoms->sample();
+                }
+            ),
+            0,
+            $n
+        );
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "hoa/console"   : "~2.0",
         "hoa/core"      : "~2.0",
         "hoa/dispatcher": "~0.0",
+        "hoa/iterator"  : "~1.0",
         "hoa/math"      : "~0.0",
         "hoa/praspel"   : "~0.0",
         "hoa/realdom"   : "~0.0",


### PR DESCRIPTION
It saves a lot of memory when sampling a lot of data.

Asking a review from @jubianchi and other @hoaproject/hoackers.
