### PR TITLE
Fix atoum dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "source": "http://git.hoa-project.net/"
     },
     "require": {
-        "atoum/atoum"   : "~1.0",
+        "atoum/atoum"   : "~2.0",
         "hoa/console"   : "~2.0",
         "hoa/core"      : "~2.0",
         "hoa/dispatcher": "~0.0",


### PR DESCRIPTION
Composer cannot clone the latest version of praspel extension if we ask atoum ~2.0 specificaly.